### PR TITLE
Adding date-rename-jpg.sh which fixes #57

### DIFF
--- a/date-rename-jpg.sh
+++ b/date-rename-jpg.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+for f in *.jpg ; do mv -iv "$f" "$(date -I)-$f" ; done


### PR DESCRIPTION
This small script renames all the jpg file present in current directory with ISO-8610 date prefix as mentioned in #57. The date prefix is the current day, provided by system time.
![image](https://user-images.githubusercontent.com/79687674/194728852-ca70317f-bf28-4583-9c1b-77e01ea6e357.png)
